### PR TITLE
feat: build and run from Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:20.04
+RUN \
+  # configure the "jhipster" user
+  groupadd jhipster && \
+  useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
+  echo 'jhipster:jhipster' |chpasswd && \
+  mkdir /home/jhipster/app && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  export TZ=Europe\Paris && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+  apt-get update && \
+  # install utilities
+  apt-get install -y \
+    wget \
+    sudo && \
+  # install node.js
+  wget https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.gz -O /tmp/node.tar.gz && \
+  tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
+  # upgrade npm
+  npm install -g npm && \
+  # install yeoman
+  npm install -g yo && \
+  # cleanup
+  apt-get clean && \
+  rm -rf \
+    /home/jhipster/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# install jhipster
+RUN npm install -g generator-jhipster
+
+RUN \
+  # install the blueprint
+  npm install -g generator-jhipster-primeng-blueprint && \
+  # fix jhipster user permissions
+  chown -R jhipster:jhipster \
+    /home/jhipster \
+    /usr/local/lib/node_modules && \
+  # cleanup
+  rm -rf \
+    /home/jhipster/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# expose the working directory
+USER jhipster
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/jhipster/app"
+VOLUME ["/home/jhipster/app"]
+CMD ["jhipster", "--blueprints", "primeng-blueprint", "--skip-checks"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,40 @@ To use this blueprint, run the below command
 jhipster --blueprint primeng-blueprint
 ```
 
+## Using Docker
+
+Download the Dockerfile:
+
+```bash
+mkdir docker
+cd docker
+wget https://github.com/elhoutico/jhipster-primeng-blueprint/raw/master/Dockerfile
+```
+
+Build the Docker images:
+
+```bash
+docker build -t jhipster-primeng-blueprint:latest .
+```
+
+Make a folder where you want to generate the Service:
+
+```bash
+mkdir service
+cd service
+```
+
+Run the generator from image to generate service:
+
+```bash
+docker run -it --rm -v $PWD:/home/jhipster/app jhipster-primeng-blueprint
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/jhipster/app jhipster-primeng-blueprint /bin/bash
+```
 
 ## Running local Blueprint version for development
 


### PR DESCRIPTION
Build and run the generator from docker image support added.

The main aim and motivation behind doing this is, because
of a no. of different jhipster blueprints are there,
which are compatible and works with the different version of jhipster
and also might be incompatible with other blueprints or versions of jhipster.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>